### PR TITLE
OJS 3.3 RC2 - Missing comma causing syntax error

### DIFF
--- a/pages/management/ManagementHandler.inc.php
+++ b/pages/management/ManagementHandler.inc.php
@@ -123,7 +123,7 @@ class ManagementHandler extends Handler {
 			$currentVersion = VersionCheck::getCurrentDBVersion();
 			$templateMgr->assign([
 				'newVersionAvailable' =>  true,
-				'currentVersion' => $currentVersion->getVersionString()
+				'currentVersion' => $currentVersion->getVersionString(),
 				'latestVersion' =>  $latestVersion,
 			]);
 


### PR DESCRIPTION
The following error is caused by a missing comma at the of line.
Parse error: syntax error, unexpected ''latestVersion'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in /lib/pkp/pages/management/ManagementHandler.inc.php on line 127